### PR TITLE
Update to fix 'txt' processing label mismatch

### DIFF
--- a/util.py
+++ b/util.py
@@ -671,7 +671,7 @@ class processInput:
                     try:
                         st = self.subtypes_dict[subtype]
                     except KeyError:
-                        continue ##This is an addition from me- ignore entries that have an N on either side because you can't do signature analysis with them anyways. Jfc this wasn't already included
+                        continue ##This is an addition from Jakob McBroome- ignore entries that have an N on either side or otherwise don't fit into the subtype dictionary.
                     if sample not in samples_dict:
                         samples_dict[sample] = {}
 
@@ -680,12 +680,8 @@ class processInput:
                     else:
                         samples_dict[sample][subtype] += 1
             mdf = pd.DataFrame(samples_dict).T.fillna(0)
-            samples = mdf.index.tolist()
-            util_log.debug("MyDebug SampleSet: {}".format(samples))
-            M = mdf.values
-            #samples = sorted(samples_dict) #another addition from me, attempting to resolve an issue where they're independently sorting the label column and making a giant mess of things.
-            #util_log.debug("MyDebug Columns: {}".format(samples))
-            #samples = samples_dict
+            samples = mdf.index.tolist() #instead of using samples_dict with sorted(), which leads to mismatching, simply retain the explicit ordering of the matrix dataframe.
+            M = mdf.values 
 
         out = collections.namedtuple('Out', ['M', 'samples'])(M, samples)
         return out
@@ -829,10 +825,8 @@ class writeOutput:
 
     def writeM(self, count_matrix):
         """ write M matrix """
-        util_log.debug("MyDebug Subtypes: {} {}".format(len(self.subtypes_dict.keys()), list(sorted(self.subtypes_dict.keys()))))
-        util_log.debug("MyDebug CountMat: {}, {}".format(count_matrix.shape, count_matrix))
         count_matrix_df = pd.DataFrame(
-            data=count_matrix, #getting len of unsized object error.
+            data=count_matrix,
             index=self.samples[0],
             columns=list(sorted(self.subtypes_dict.keys())))
         count_matrix_df.to_csv(

--- a/util.py
+++ b/util.py
@@ -668,10 +668,10 @@ class processInput:
                         # eprint("lseq:", lseq)
                     motif_a = getMotif(lseq)
                     subtype = str(category + "." + motif_a)
-                    try:
-                        st = self.subtypes_dict[subtype]
-                    except KeyError:
-                        continue ##This is an addition from Jakob McBroome- ignore entries that have an N on either side or otherwise don't fit into the subtype dictionary.
+                    
+                    if subtype not in self.subtypes_dict:
+                        continue
+
                     if sample not in samples_dict:
                         samples_dict[sample] = {}
 
@@ -825,6 +825,7 @@ class writeOutput:
 
     def writeM(self, count_matrix):
         """ write M matrix """
+
         count_matrix_df = pd.DataFrame(
             data=count_matrix,
             index=self.samples[0],


### PR DESCRIPTION
I've included two changes.

1. I removed an unused variable defining line and replaces it with a check that the subtype falls into the dictionary of valid subtypes (previously it would throw an error, now it will simply ignore mutations adjacent to N or otherwise have strange errors).
2. I fixed a bug that leads to label mismatching by independent sorting of the label vector, which occurs when rows are not alphabetically sorted by sample within the input text file (if they are sorted by position instead, for example). It can now handle any ordering correctly.

All changes are limited to the process_txt input option and should not affect functionality for any other mode.